### PR TITLE
Use <symbol> instead of <g>?

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,21 @@
+{
+  "asi": true,
+  "boss": true,
+  "browser": true,
+  "node": true,
+  "expr": true,
+  "globals": {
+    "define": false,
+    "require": true,
+    "_t": true
+  },
+  "indent": 2,
+  "laxcomma": true,
+  "maxlen": 100,
+  "newcap": true,
+  "strict": false,
+  "trailing": true,
+  "undef": true,
+  "unused": true,
+  "quotmark": "single"
+}

--- a/README.md
+++ b/README.md
@@ -1,18 +1,25 @@
 gulp-svgstore
 =============
 
-Combine svg files into one with defs. Read more about this in [CSS Tricks article](http://css-tricks.com/svg-sprites-use-better-icon-fonts/).
+Combine svg files into one with <symbol> elements.
+Read more about this in [CSS Tricks article](http://css-tricks.com/svg-symbol-good-choice-icons/).
+
+## Caution:
+
+This is still incomplete and api may be changed anytime.
+I plan to add tests and then freeze api.
 
 ## Options:
 
 * fileName — the name of result file
-* prefix — prefix for ids of the defs child elements
-* onlySvg — output only `<svg>` element without `<?xml ?>` and `DOCTYPE`
+* prefix — prefix for ids of the <symbol> elements
+* inlineSvg — output only `<svg>` element without `<?xml ?>` and `DOCTYPE` to use inline
 * emptyFills - remove all fill="none" so they can be changed in css
 
 ## Usage
 
-The following script will combine circle.svg and square.svg into single svg file with defs.
+The following script will combine circle.svg and square.svg into single svg file with
+<symbol> elements.
 
 ```
 var svgstore = require('gulp-svgstore')
@@ -21,22 +28,25 @@ var svgmin = require('gulp-svgmin')
 gulp.task('default', function () {
   return gulp.src('test/fixtures/*.svg')
              .pipe(svgmin())
-             .pipe(svgstore({fileName: 'icons.svg', prefix: 'icon-', onlySvg: false}))
+             .pipe(svgstore({ fileName: 'icons.svg'
+                            , prefix: 'icon-'
+                            , inlineSvg: false
+                            }))
              .pipe(gulp.dest('test/'))
 })
 ```
 
+Combined svg:
+
 ```
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg>
-  <defs>
-    <g id="icon-circle">
-      <circle fill="#fff" stroke="#1D1D1B" stroke-miterlimit="10" cx="20" cy="20" r="10"/>
-    </g>
-    <g id="icon-square">
-      <path fill="#fff" stroke="#1D1D1B" stroke-miterlimit="10" d="M10 10h20v20h-20z"/>
-    </g>
-  </defs>
+<svg xmlns="http://www.w3.org/2000/svg">
+  <symbol id="icon-circle" viewBox="0 0 40 40">
+    <circle fill="#fff" stroke="#1D1D1B" stroke-miterlimit="10" cx="20" cy="20" r="10"/>
+  </symbol>
+  <symbol id="icon-square" viewBox="0 0 40 40">
+    <path stroke="#1D1D1B" stroke-miterlimit="10" d="M10 10h20v20h-20z"/>
+  </symbol>
 </svg>
 ```

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,7 +8,7 @@ gulp.task('default', function () {
              .pipe(svgmin())
              .pipe(svgstore({ fileName: 'icons.svg'
                             , prefix: 'icon-'
-                            , onlySvg: true
+                            , inlineSvg: false
                             , emptyFills: true
                             }))
              .pipe(gulp.dest('test/'))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-svgstore",
-  "version": "0.0.5",
-  "description": "Combine svg files into one with defs",
+  "version": "0.0.6",
+  "description": "Combine svg files into one with <symbol> elements",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Hey,

grunt-svgstore switched from `<g>` to `<symbol>`. Any chance you will, too?
Chris Coyier wrote about why it's better: [CSS-Tricks](http://css-tricks.com/svg-symbol-good-choice-icons/)

Have a nice day
— Martin
