### PR TITLE
Symbol IDs will now automatically be made unique

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,8 +41,13 @@ module.exports = function (config) {
     var viewBoxAttr = $svg.attr('viewBox')
     var $symbol = $('<symbol/>')
 
-    if (idAttr in ids) {
-      return cb(new gutil.PluginError('gulp-svgstore', 'File name should be unique: ' + idAttr))
+    while (idAttr in ids) {
+      if (!idAttr.match(/-[0-9]+$/)) {
+        idAttr += "-1"
+      } else {
+        var index = idAttr.lastIndexOf('-') + 1
+        idAttr = idAttr.substr(0,index) + (parseInt(idAttr.substr(index)) + 1)
+      }
     }
 
     ids[idAttr] = true


### PR DESCRIPTION
Originally, the script would simply error out if any of the symbol id's were not unique. This would happen in a situation where two files had the same filename, which would result in two `<symbol>`s in the svg having the same id, which is not advised, hence the reason the script just error'ed out if it encountered this.

This code change appends a dash `-` and a number to the end of non-unique ids. The first number chosen is always a `1`. If another id already exists with that number, then the number is incremented to 2 and so on, until it fines a unique id name.