### PR TITLE
Manage svg root element's attributes of sprites

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ module.exports = function (config) {
     $symbol.attr('id', idAttr)
     
     for(var attrName in attrs)
-      if( blacklistAttribute.indexOf(attrName) < 0){
+      if(blacklistAttributes.indexOf(attrName) < 0){
         //special treatment for namespaces
         if(attrName.match(/xmlns:.+/)){
           var storedNs = namespaces[attrName],

--- a/index.js
+++ b/index.js
@@ -38,10 +38,12 @@ module.exports = function (config) {
     }
 
     var $svg = file.cheerio('svg')
-    if($svg.length < 1)
+    if($svg.length < 1){
       return cb()//not an svg file apparently
+    }
 
     var idAttr = path.basename(file.relative, path.extname(file.relative))
+    var viewBoxAttr = $svg.attr('viewBox')
     var $symbol = $('<symbol/>')
 
     if (idAttr in ids) {
@@ -64,6 +66,9 @@ module.exports = function (config) {
     }
 
     $symbol.attr('id', idAttr)
+    if (viewBoxAttr) {
+-      $symbol.attr('viewBox', viewBoxAttr)
+    }
     
     var attrs = $svg[0].attribs
     for(var attrName in attrs){

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var Stream = require('stream')
 module.exports = function (config) {
 
   config = config || {}
-  
+
   var namespaces = {}
   var isEmpty = true
   var fileName

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ module.exports = function (config) {
 
     $symbol.attr('id', idAttr)
     if (viewBoxAttr) {
--      $symbol.attr('viewBox', viewBoxAttr)
+      $symbol.attr('viewBox', viewBoxAttr)
     }
     
     var attrs = $svg[0].attribs

--- a/test.js
+++ b/test.js
@@ -39,7 +39,7 @@ function compareScreenshots (path1, path2) {
   })
 }
 
-
+/*
 describe('gulp-svgstore usage test', function () {
 
   this.timeout(10000)
@@ -89,10 +89,10 @@ describe('gulp-svgstore usage test', function () {
   })
 
 })
-
+*/
 
 describe('gulp-svgstore unit test', function () {
-
+/*
   it('should not create empty svg file', function (done) {
 
     var stream = svgstore()
@@ -278,6 +278,106 @@ describe('gulp-svgstore unit test', function () {
 
       stream.end()
 
+  })
+*/
+  it('should include all namespace into final svg', function (done) {
+
+      var stream = svgstore()
+
+      stream.on('data', function (file) {
+        var $resultSvg = cheerio.load(file.contents.toString(), { xmlMode: true })('svg')
+
+      assert.equal( $resultSvg.attr('xmlns' ), 'http://www.w3.org/2000/svg')
+      assert.equal( $resultSvg.attr('xmlns:xlink' ), 'http://www.w3.org/1999/xlink')
+      done()
+      })
+
+      stream.write(new gutil.File({
+        contents: new Buffer(
+          '<svg xmlns="http://www.w3.org/2000/svg">' +
+            '<rect width="1" height="1"/>' +
+          '</svg>')
+      , path: 'rect.svg'
+      }))
+
+      stream.write(new gutil.File({
+        contents: new Buffer(
+          '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"' + 
+              'viewBox="0 0 50 50">' + 
+            '<rect id="a" width="50" height="10"/>' + 
+            '<use y="20" xlink:href="#a"/>' + 
+            '<use y="40" xlink:href="#a"/>' + 
+          '</svg>')
+      , path: 'sandwich.svg'
+      }))
+
+      stream.end()
+
+  })
+
+  it('Warn about duplicate namespace value under different name', function (done) {
+
+      var stream = svgstore()
+
+      stream.on('data', function () {
+        //TODO test stdout
+      done()
+      })
+
+      stream.write(new gutil.File({
+        contents: new Buffer(
+          '<svg xmlns="http://www.w3.org/2000/svg" xmlns:lk="http://www.w3.org/1999/xlink">' +
+            '<rect id="a" width="1" height="1"/>' +
+            '<use y="2" lk:href="#a"/>' +
+          '</svg>')
+      , path: 'rect.svg'
+      }))
+
+      stream.write(new gutil.File({
+        contents: new Buffer(
+          '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"' + 
+              'viewBox="0 0 50 50">' + 
+            '<rect id="a" width="50" height="10"/>' + 
+            '<use y="20" xlink:href="#a"/>' + 
+            '<use y="40" xlink:href="#a"/>' + 
+          '</svg>')
+      , path: 'sandwich.svg'
+      }))
+
+      stream.end()
+
+  })
+
+  it('Strong warn about duplicate namespace name with different value', function (done) {
+
+      var stream = svgstore()
+
+      stream.on('data', function () {
+        //TODO test stdout
+      done()
+      })
+
+      stream.write(new gutil.File({
+        contents: new Buffer(
+          '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1998/xlink">' +
+            '<rect id="a" width="1" height="1"/>' +
+            '<use y="2" xlink:href="#a"/>' +
+          '</svg>')
+      , path: 'rect.svg'
+      }))
+
+      stream.write(new gutil.File({
+        contents: new Buffer(
+          '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"' + 
+              'viewBox="0 0 50 50">' + 
+            '<rect id="a" width="50" height="10"/>' + 
+            '<use y="20" xlink:href="#a"/>' + 
+            '<use y="40" xlink:href="#a"/>' + 
+          '</svg>')
+      , path: 'sandwich.svg'
+      }))
+
+      stream.end()
   })
 
 })

--- a/test.js
+++ b/test.js
@@ -39,7 +39,6 @@ function compareScreenshots (path1, path2) {
   })
 }
 
-/*
 describe('gulp-svgstore usage test', function () {
 
   this.timeout(10000)
@@ -89,10 +88,8 @@ describe('gulp-svgstore usage test', function () {
   })
 
 })
-*/
 
 describe('gulp-svgstore unit test', function () {
-/*
   it('should not create empty svg file', function (done) {
 
     var stream = svgstore()
@@ -279,7 +276,7 @@ describe('gulp-svgstore unit test', function () {
       stream.end()
 
   })
-*/
+
   it('should include all namespace into final svg', function (done) {
 
       var stream = svgstore()

--- a/test.js
+++ b/test.js
@@ -92,7 +92,7 @@ describe('gulp-svgstore usage test', function () {
 
 
 describe('gulp-svgstore unit test', function () {
- 
+
   it('should not create empty svg file', function (done) {
 
     var stream = svgstore()

--- a/test.js
+++ b/test.js
@@ -92,7 +92,7 @@ describe('gulp-svgstore usage test', function () {
 
 
 describe('gulp-svgstore unit test', function () {
-  
+ 
   it('should not create empty svg file', function (done) {
 
     var stream = svgstore()

--- a/test.js
+++ b/test.js
@@ -39,6 +39,7 @@ function compareScreenshots (path1, path2) {
   })
 }
 
+
 describe('gulp-svgstore usage test', function () {
 
   this.timeout(10000)
@@ -89,7 +90,9 @@ describe('gulp-svgstore usage test', function () {
 
 })
 
+
 describe('gulp-svgstore unit test', function () {
+  
   it('should not create empty svg file', function (done) {
 
     var stream = svgstore()


### PR DESCRIPTION
This pull request allows gulp-svgstore to copy sprites svg's attributes (filtered by a blacklist) into generated symbol element.
We don't want to copy all attributes so I've introduced a blacklist (seems more reasonnable than a whitelist) to exclude some attributes.

Also I had a problem when using ```<use>``` tag inside symbol element because of the lack of namespace ```xlink``` on the generated svg file.
So we also copy namespaces included on sprite into the generated svg.
A warning message is shown if we found same namespace name with different values. 

This way gulp-svgstore should be able to handles sprites like that : 
```
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="#fff">
  ....
</svg>
```

or

```
<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 100 100">
  <use xlink:href="sprite1"/>
  ....
</svg>
``` 

I'm pretty sure attribute's blacklist may be upgrade. 