### PR TITLE
Make fileName configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ The following options are set automatically based on file data:
 
 If your workflow is different, please use `gulp-rename` to rename sources or result.
 
-The only available option is:
+The following properties can be configured using the `config` argument:
 
+* fileName - Overwrite the svg sprite's file name, default: name of the source's base directory.
 * inlineSvg — output only `<svg>` element without `<?xml ?>` and `DOCTYPE` to use inline, default: `false`.
 
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = function (config) {
 
   var namespaces = {}
   var isEmpty = true
-  var fileName
+  var fileName = config.fileName || false
   var inlineSvg = config.inlineSvg || false
   var ids = {}
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = function (config) {
 
   var namespaces = {}
   var isEmpty = true
-  var fileName = config.fileName || false
+  var fileName = typeof config.fileName === 'string' ? config.fileName.replace(/\.svg$/, '') : false
   var inlineSvg = config.inlineSvg || false
   var ids = {}
 


### PR DESCRIPTION
It seems the module was designed to make it possible for the user to configure the resulting sprite's file name, yet at this point variable `fileName` will never be assigned a value.