### PR TITLE
Preserve non-svg files in stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ module.exports = function (config) {
 
     if (file.isNull()) return cb()
 
+    if (path.extname(file.relative) !== '.svg') return cb(null, file)
 
     var $svg = cheerio.load(file.contents.toString(), { xmlMode: true })('svg')
 

--- a/index.js
+++ b/index.js
@@ -37,7 +37,10 @@ module.exports = function (config) {
 
     if (file.isNull()) return cb()
 
-    if (path.extname(file.relative) !== '.svg') return cb(null, file)
+    if (path.extname(file.relative) !== '.svg') {
+      this.push(file);
+      return cb();
+    }
 
     var $svg = cheerio.load(file.contents.toString(), { xmlMode: true })('svg')
 


### PR DESCRIPTION
In case the stream includes non-svg files as well (i.e. json files with meta data), there will be no use trying to parse these files with cheerio. Also, quite possibly the user will want to preserve these files for different purposes.